### PR TITLE
Fix: Remove default DetailType from DepositLine to support LinkedTxn

### DIFF
--- a/quickbooks/objects/deposit.py
+++ b/quickbooks/objects/deposit.py
@@ -53,7 +53,6 @@ class DepositLine(QuickbooksBaseObject):
         self.LineNum = 0
         self.Description = ""
         self.Amount = 0
-        self.DetailType = "DepositLineDetail"
         self.LinkedTxn = []
         self.CustomField = []
 

--- a/tests/unit/objects/test_deposit.py
+++ b/tests/unit/objects/test_deposit.py
@@ -2,6 +2,7 @@ import unittest
 
 from quickbooks import QuickBooks
 from quickbooks.objects.deposit import Deposit, DepositLine, CashBackInfo, DepositLineDetail
+from quickbooks.objects.base import LinkedTxn
 
 
 class DepositTests(unittest.TestCase):
@@ -25,6 +26,25 @@ class DepositLineTests(unittest.TestCase):
         deposit.Amount = 100
 
         self.assertEqual(str(deposit), "100")
+
+    def test_init_no_detail_type(self):
+        deposit_line = DepositLine()
+        self.assertFalse(hasattr(deposit_line, 'DetailType'))
+
+    def test_to_dict_with_linked_txn(self):
+        deposit_line = DepositLine()
+        deposit_line.Amount = 100
+
+        linked_txn = LinkedTxn()
+        linked_txn.TxnId = "123"
+        linked_txn.TxnType = "Payment"
+        linked_txn.TxnLineId = 0
+        deposit_line.LinkedTxn.append(linked_txn)
+
+        result = deposit_line.to_dict()
+        self.assertNotIn('DetailType', result)
+        self.assertEqual(result['Amount'], 100)
+        self.assertEqual(len(result['LinkedTxn']), 1)
 
 
 class CashBackInfoTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #329 

The DepositLine class was automatically setting DetailType = "DepositLineDetail" in the constructor, which caused conflicts when creating deposit lines with linked transactions. The QuickBooks API expects DetailType to be set appropriately based on the context, not hardcoded.
